### PR TITLE
docs: add link to ixy.js thesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some languages require a few lines of C stubs for features not offered by the la
 | OCaml      | [ixy.ml](https://github.com/ixy-languages/ixy.ml)       | Finished | [Documentation](https://github.com/ixy-languages/ixy.ml/blob/master/README.md)                                                                            |
 | Haskell    | [ixy.hs](https://github.com/ixy-languages/ixy.hs)       | Finished | [Thesis](https://www.net.in.tum.de/fileadmin/bibtex/publications/theses/2019-ixy-haskell.pdf)                                                             |
 | Swift      | [ixy.swift](https://github.com/ixy-languages/ixy.swift) | Finished | [Documentation](https://github.com/ixy-languages/ixy.swift/blob/master/README.md)                                                                         |
-| Javascript | [ixy.js](https://github.com/ixy-languages/ixy.js)       | Finished | (WIP)                                                                                                                                                     |
+| Javascript | [ixy.js](https://github.com/ixy-languages/ixy.js)       | Finished | [Thesis](https://github.com/ixy-languages/ixy.js/blob/master/thesis.pdf)                                                                                  |
 | Python     | [ixy.py](https://github.com/ixy-languages/ixy.py)*      | Finished | (WIP)                                                                                                                                                     |
 
 


### PR DESCRIPTION
Adds the link to the finished thesis of the ixy.js implementation. It has been finished for quite some time, but the link was never added in the past because the paper wasnt publically available anywhere. Now that it's part of the ixy.js repo, we can link to it.